### PR TITLE
Add scan for all running ec2 instance with tags

### DIFF
--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -1,5 +1,5 @@
 import logging
-from actions import check_alarm_tag, process_alarm_tags, delete_alarms, process_lambda_alarms
+from actions import check_alarm_tag, process_alarm_tags, delete_alarms, process_lambda_alarms, scan_and_process_alarm_tags
 from os import getenv
 
 logger = logging.getLogger()
@@ -159,6 +159,12 @@ def lambda_handler(event, context):
             function = event['detail']['requestParameters']['functionName']
             logger.debug('Delete Lambda Function event occurred for: {}'.format(function))
             result = delete_alarms(function)
+        elif  'action' in event and event['action'] == 'scan':
+            logger.debug(
+                f'Scanning for EC2 instances with tag: {create_alarm_tag} to create alarm'
+            )
+            scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensions_map, sns_topic_arn,
+                                   cw_namespace, create_default_alarms_flag, alarm_separator)
 
     except Exception as e:
         # If any other exceptions which we didn't expect are raised


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/amazon-cloudwatch-auto-alarms/issues/11

*Description of changes:*
Add ability to scan for all running ec2 with tags so you don't need to reboot boxes for lambda to trigger. The lambda can be triggered with a payload of {'action': 'scan'}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
