### PR TITLE
Enhancements/partition-arn-and-dynamic-prefix-separator

### DIFF
--- a/CloudWatchAutoAlarms.yaml
+++ b/CloudWatchAutoAlarms.yaml
@@ -83,11 +83,11 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - logs:DescribeLogGroups
-                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*"
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*"
               - Effect: Allow
                 Action:
                   - ec2:DescribeInstances
@@ -96,13 +96,13 @@ Resources:
               - Effect: Allow
                 Action:
                   - ec2:CreateTags
-                Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+                Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
               - Effect: Allow
                 Action:
                   - cloudwatch:DescribeAlarms
                   - cloudwatch:DeleteAlarms
                   - cloudwatch:PutMetricAlarm
-                Resource:  !Sub "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:AutoAlarm-*"
+                Resource:  !Sub "arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:AutoAlarm-*"
               - Effect: Allow
                 Action:
                   - cloudwatch:DescribeAlarms

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following list provides a description of the setting along with the environm
     * You can change the namespace where the Lambda function should look for your CloudWatch metrics. The default CloudWatch agent metrics namespace is CWAgent.  If your CloudWatch agent configuration is using a different namespace, then update the  CLOUDWATCH_NAMESPACE environment variable.
 * **CLOUDWATCH_APPEND_DIMENSIONS**: InstanceId, ImageId, InstanceType, AutoScalingGroupName 
     * You can add EC2 metric dimensions to all metrics collected by the CloudWatch agent.  This environment variable aligns to your CloudWatch configuration setting for [**append_dimensions**](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Metricssection).  The default setting includes all the supported dimensions:  InstanceId, ImageId, InstanceType, AutoScalingGroupName
-* **DEFAULT_ALARM_SNS_TOPIC_ARN**:  arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CloudWatchAutoAlarmsSNSTopic
+* **DEFAULT_ALARM_SNS_TOPIC_ARN**:  arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:CloudWatchAutoAlarmsSNSTopic
     * You can define an Amazon Simple Notification Service (Amazon SNS) topic that the Lambda function will specify as the notification target for created alarms. You provide the Amazon SNS Topic Amazon Resource Name (ARN) with the **AlarmNotificationARN** parameter when you deploy the CloudWatchAutoAlarms.yaml CloudFormation template.  If you leave the **AlarmNotificationARN** parameter value blank, then this environment variable is not set and created alarms won't use notifications.
 * You can update the thresholds for the default alarms by updating the following environment variables:
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -159,8 +159,8 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
         raise Exception
 
     AlarmName = alarm_separator.join([alarm_identifier, id, namespace, MetricName])
-
     properties_offset = 0
+
     if additional_dimensions:
         for num, dim in enumerate(additional_dimensions[::2]):
             val = additional_dimensions[num * 2 + 1]

--- a/src/actions.py
+++ b/src/actions.py
@@ -78,7 +78,7 @@ def check_alarm_tag(instance_id, tag_key):
         raise
 
 
-def process_lambda_alarms(function_name, tags, activation_tag, default_alarms, sns_topic_arn, alarm_separator):
+def process_lambda_alarms(function_name, tags, activation_tag, default_alarms, sns_topic_arn, alarm_separator, alarm_identifier):
     activation_tag = tags.get(activation_tag, 'not_found')
     if activation_tag == 'not_found':
         logger.debug('Activation tag not found for {}, nothing to do'.format(function_name))
@@ -86,7 +86,7 @@ def process_lambda_alarms(function_name, tags, activation_tag, default_alarms, s
     else:
         logger.debug('Processing function specific alarms for: {}'.format(default_alarms))
         for tag_key in tags:
-            if tag_key.startswith('AutoAlarm'):
+            if tag_key.startswith(alarm_identifier):
                 default_alarms['AWS/Lambda'].append({'Key': tag_key, 'Value': tags[tag_key]})
 
         # get the default dimensions for AWS/EC2
@@ -106,14 +106,13 @@ def process_lambda_alarms(function_name, tags, activation_tag, default_alarms, s
             Period = alarm_properties[4]
             Statistic = alarm_properties[5]
 
-            AlarmName = 'AutoAlarm-{}-{}-{}-{}-{}-{}'.format(function_name, Namespace, MetricName, ComparisonOperator,
-                                                             Period,
-                                                             Statistic)
+            AlarmName = '{}-{}-{}-{}-{}-{}-{}'.format(alarm_identifier, function_name, Namespace, MetricName, ComparisonOperator,
+                                                        Period, Statistic)
             create_alarm(AlarmName, MetricName, ComparisonOperator, Period, tag['Value'], Statistic, Namespace,
-                         dimensions, sns_topic_arn)
+                         dimensions, sns_topic_arn, alarm_identifier)
 
 
-def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator):
+def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator, alarm_identifier):
     alarm_properties = alarm_tag['Key'].split(alarm_separator)
     namespace = alarm_properties[1]
     MetricName = alarm_properties[2]
@@ -158,7 +157,7 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
         logger.error('Unable to determine the dimensions for alarm tag: {}'.format(alarm_tag))
         raise Exception
 
-    AlarmName = 'AutoAlarm-{}-{}-{}'.format(id, namespace, MetricName)
+    AlarmName = '{}-{}-{}-{}'.format(alarm_identifier, id, namespace, MetricName)
     properties_offset = 0
     if additional_dimensions:
         for num, dim in enumerate(additional_dimensions[::2]):
@@ -183,7 +182,7 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
 
 
 def process_alarm_tags(instance_id, instance_info, default_alarms, metric_dimensions_map, sns_topic_arn, cw_namespace,
-                       create_default_alarms_flag, alarm_separator):
+                       create_default_alarms_flag, alarm_separator, alarm_identifier):
     tags = instance_info['Tags']
 
     ImageId = instance_info['ImageId']
@@ -194,15 +193,15 @@ def process_alarm_tags(instance_id, instance_info, default_alarms, metric_dimens
     custom_alarms = dict()
     # get all alarm tags from instance and add them into a custom tag list
     for instance_tag in tags:
-        if instance_tag['Key'].startswith('AutoAlarm'):
-            create_alarm_from_tag(instance_id, instance_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator)
+        if instance_tag['Key'].startswith(alarm_identifier):
+            create_alarm_from_tag(instance_id, instance_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator, alarm_identifier)
 
     if create_default_alarms_flag == 'true':
         for alarm_tag in default_alarms['AWS/EC2']:
-            create_alarm_from_tag(instance_id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator)
+            create_alarm_from_tag(instance_id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator, alarm_identifier)
 
         for alarm_tag in default_alarms[cw_namespace][platform]:
-            create_alarm_from_tag(instance_id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator)
+            create_alarm_from_tag(instance_id, alarm_tag, instance_info, metric_dimensions_map, sns_topic_arn, alarm_separator, alarm_identifier)
     else:
         logger.info("Default alarm creation is turned off")
 
@@ -257,7 +256,7 @@ def convert_to_seconds(s):
         raise
 
 
-# Alarm Name Format: AutoAlarm-<InstanceId>-<Statistic>-<MetricName>-<ComparisonOperator>-<Threshold>-<Period>
+# Alarm Name Format: <AlarmIdentifier>-<InstanceId>-<Statistic>-<MetricName>-<ComparisonOperator>-<Threshold>-<Period>
 # Example:  AutoAlarm-i-00e4f327736cb077f-CPUUtilization-GreaterThanThreshold-80-5m
 def create_alarm(AlarmName, MetricName, ComparisonOperator, Period, Threshold, Statistic, Namespace, Dimensions,
                  sns_topic_arn):
@@ -302,9 +301,9 @@ def create_alarm(AlarmName, MetricName, ComparisonOperator, Period, Threshold, S
             'Error creating alarm {}!: {}'.format(AlarmName, e))
 
 
-def delete_alarms(name):
+def delete_alarms(name, alarm_identifier):
     try:
-        AlarmNamePrefix = "AutoAlarm-{}".format(name)
+        AlarmNamePrefix = "{}-{}".format(alarm_identifier, name)
         cw_client = boto3_client('cloudwatch')
         logger.info('calling describe alarms with prefix {}'.format(AlarmNamePrefix))
         response = cw_client.describe_alarms(
@@ -328,7 +327,7 @@ def delete_alarms(name):
             'Error deleting alarms for {}!: {}'.format(name, e))
 
 def scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensions_map, sns_topic_arn,
-                                   cw_namespace, create_default_alarms_flag, alarm_separator):
+                                   cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier):
     try:
         ec2_client = boto3_client('ec2')
         for reservation in ec2_client.describe_instances()["Reservations"]:
@@ -338,7 +337,7 @@ def scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensi
                     continue
                 if check_alarm_tag(instance["InstanceId"], create_alarm_tag):
                     process_alarm_tags(instance["InstanceId"], instance, default_alarms, metric_dimensions_map,
-                     sns_topic_arn, cw_namespace, create_default_alarms_flag, alarm_separator)
+                     sns_topic_arn, cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier)
 
     except Exception as e:
         # If any other exceptions which we didn't expect are raised

--- a/src/actions.py
+++ b/src/actions.py
@@ -170,14 +170,14 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
                     'Value': val
                 }
             )
-            AlarmName = AlarmName + alarm_separator.join(['', dim, val])
+            AlarmName += alarm_separator.join(['', dim, val])
             properties_offset = properties_offset + 2
 
     ComparisonOperator = alarm_properties[(properties_offset + 3)]
     Period = alarm_properties[(properties_offset + 4)]
     Statistic = alarm_properties[(properties_offset + 5)]
 
-    AlarmName = AlarmName + alarm_separator.join(['', ComparisonOperator, Period, Statistic])
+    AlarmName += alarm_separator.join(['', ComparisonOperator, Period, Statistic])
 
     create_alarm(AlarmName, MetricName, ComparisonOperator, Period, alarm_tag['Value'], Statistic, namespace,
                  dimensions, sns_topic_arn)

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -143,28 +143,28 @@ def lambda_handler(event, context):
             # instance has been tagged for alarming, confirm an alarm doesn't already exist
             if instance_info:
                 process_alarm_tags(instance_id, instance_info, default_alarms, metric_dimensions_map, sns_topic_arn,
-                                   cw_namespace, create_default_alarms_flag, alarm_separator)
+                                   cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier)
         elif 'source' in event and event['source'] == 'aws.ec2' and event['detail']['state'] == 'terminated':
             instance_id = event['detail']['instance-id']
-            result = delete_alarms(instance_id)
+            result = delete_alarms(instance_id, alarm_identifier)
         elif 'source' in event and event['source'] == 'aws.lambda' and event['detail'][
             'eventName'] == 'TagResource20170331v2':
             logger.debug(
                 'Tag Lambda Function event occurred, tags are: {}'.format(event['detail']['requestParameters']['tags']))
             tags = event['detail']['requestParameters']['tags']
             function = event['detail']['requestParameters']['resource'].split(":")[-1]
-            process_lambda_alarms(function, tags, create_alarm_tag, default_alarms, sns_topic_arn, alarm_separator)
+            process_lambda_alarms(function, tags, create_alarm_tag, default_alarms, sns_topic_arn, alarm_separator, alarm_identifier)
         elif 'source' in event and event['source'] == 'aws.lambda' and event['detail'][
             'eventName'] == 'DeleteFunction20150331':
             function = event['detail']['requestParameters']['functionName']
             logger.debug('Delete Lambda Function event occurred for: {}'.format(function))
-            result = delete_alarms(function)
+            result = delete_alarms(function, alarm_identifier)
         elif  'action' in event and event['action'] == 'scan':
             logger.debug(
                 f'Scanning for EC2 instances with tag: {create_alarm_tag} to create alarm'
             )
             scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensions_map, sns_topic_arn,
-                                   cw_namespace, create_default_alarms_flag, alarm_separator)
+                                   cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier)
 
     except Exception as e:
         # If any other exceptions which we didn't expect are raised

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -146,7 +146,7 @@ def lambda_handler(event, context):
                                    cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier)
         elif 'source' in event and event['source'] == 'aws.ec2' and event['detail']['state'] == 'terminated':
             instance_id = event['detail']['instance-id']
-            result = delete_alarms(instance_id, alarm_identifier)
+            result = delete_alarms(instance_id, alarm_identifier, alarm_separator)
         elif 'source' in event and event['source'] == 'aws.lambda' and event['detail'][
             'eventName'] == 'TagResource20170331v2':
             logger.debug(
@@ -158,7 +158,7 @@ def lambda_handler(event, context):
             'eventName'] == 'DeleteFunction20150331':
             function = event['detail']['requestParameters']['functionName']
             logger.debug('Delete Lambda Function event occurred for: {}'.format(function))
-            result = delete_alarms(function, alarm_identifier)
+            result = delete_alarms(function, alarm_identifier, alarm_separator)
         elif  'action' in event and event['action'] == 'scan':
             logger.debug(
                 f'Scanning for EC2 instances with tag: {create_alarm_tag} to create alarm'

--- a/ssm-cloudwatch-instance-role.yaml
+++ b/ssm-cloudwatch-instance-role.yaml
@@ -18,8 +18,8 @@ Resources:
               - sts:AssumeRole
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
-        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- ARNs use `${AWS::Partition}` pseudo param
- Replace hard-coded `'AutoAlarm'` with `alarm_identifier` variable
- Replace hard-coded `-` with `alarm_separator` variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
