### PR TITLE
Fix/windows-memory-alarm

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -160,17 +160,21 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
 
     AlarmName = 'AutoAlarm-{}-{}-{}'.format(id, namespace, MetricName)
     properties_offset = 0
-    if additional_dimensions:
-        for num, dim in enumerate(additional_dimensions[::2]):
-            val = additional_dimensions[num * 2 + 1]
-            dimensions.append(
-                {
-                    'Name': dim,
-                    'Value': val
-                }
-            )
-            AlarmName = AlarmName + '-{}-{}'.format(dim, val)
-            properties_offset = properties_offset + 2
+    try:
+        if additional_dimensions:
+            for num, dim in enumerate(additional_dimensions[::2]):
+                val = additional_dimensions[num * 2 + 1]
+                dimensions.append(
+                    {
+                        'Name': dim,
+                        'Value': val
+                    }
+                )
+                AlarmName = AlarmName + '-{}-{}'.format(dim, val)
+                properties_offset = properties_offset + 2
+    except Exception as e:
+        logger.error('Getting dimensions: {}'.format(e))
+        raise
 
     ComparisonOperator = alarm_properties[(properties_offset + 3)]
     Period = alarm_properties[(properties_offset + 4)]

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -67,7 +67,7 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'Memory % Committed Bytes In Use', 'objectname', 'Memory',
-                     'instance', 'GreaterThanThreshold', '5m', 'Average']),
+                     'GreaterThanThreshold', '5m', 'Average']),
                 'Value': alarm_memory_high_default_threshold
             }
         ],


### PR DESCRIPTION
*Issue #, if available:* Potentially relates to #17

*Description of changes:*

Encountered an issue where alarms for `Memory % Committed Bytes In Use` was not created. To troubleshoot this, I added exception handling for the section of code causing the issue. The exception raised was `list index out of range`.

Fix: There was an extra value of `instance` in the key for `Memory % Committed Bytes In Use`. Removing it fixes the issue and alarms are created successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
