### PR TITLE
Feature/add description to end of alarm name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The alarms are created and configured based on EC2 tags which include the metric
 
 The tag name syntax for AWS provided metrics is:
 
-AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>
+AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>-\<**Description**>
 
 Where:
 
@@ -36,10 +36,11 @@ You can also specify a different name as described in the **Configuration** sect
 * **ComparisonOperator** is the comparison that should be used aligning to the ComparisonOperator parameter in the [PutMetricData](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html) Amazon CloudWatch API action.
 * **Period** is the length of time used to evaluate the metric.  You can specify an integer value followed by s for seconds, m for minutes, h for hours, d for days, and w for weeks.  Your evaluation period should observe CloudWatch evaluation period limits.
 * **Statistic** is the statistic for the MetricName specified, other than percentile.
+* **Description** is the description for the CloudWatch Alarm.
 
 The tag value is used to specify the threshold.  You can also [create alarms for custom Amazon CloudWatch metrics](#alarming-on-custom-amazon-ec2-metrics).
 
-For example, one of the preconfigured, default alarms that are included in the **default_alarms** dictionary is **AutoAlarm-AWS/EC2-CPUUtilization-GreaterThanThreshold-5m-Average**.
+For example, one of the preconfigured, default alarms that are included in the **default_alarms** dictionary is **AutoAlarm-AWS/EC2-CPUUtilization-GreaterThanThreshold-5m-Average-default1**.
 When an instance with the tag key **Create_Auto_Alarms** enters the **running** state, an alarm for the AWS provided **CPUUtilization** CloudWatch EC2 metric will be created.
 Additional alarms will also be created for the EC2 instance based on the platform and alarms defined in the **default_alarms** python dictionary defined in [cw_auto_alarms.py](src/cw_auto_alarms.py).
 
@@ -142,13 +143,13 @@ You can add, remove, and customize alarms in the default alarm set.  The default
 
 In order to create an alarm, you must uniquely identify the metric that you want to alarm on.  Standard Amazon EC2 metrics include the **InstanceId** dimension to uniquely identify each standard metric associated with an EC2 instance.  If you want to add an alarm based upon a standard EC2 instance metric, then you can use the tag name syntax:
 
-AutoAlarm-AWS/EC2-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>
+AutoAlarm-AWS/EC2-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>-\<**Description**>
 
 This syntax doesn't include any dimension names because the InstanceId dimension is used for metrics in the **AWS/EC2** namespace.  These AWS provided EC2 metrics are common across all platforms for EC2.
 
 Similarly, AWS Lambda metrics include the **FunctionName** dimension to uniquely identify each standard metric associated with an AWS Lambda function.  If you want to add an alarm based upon a standard AWS Lambda metric, then you can use the tag name syntax:
 
-AutoAlarm-AWS/Lambda-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>
+AutoAlarm-AWS/Lambda-\<**MetricName**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>-\<**Description**>
 
 You can add any standard Amazon CloudWatch metric for Amazon EC2 or AWS Lambda into the **default_alarms** dictionary under the **AWS/EC2** or **AWS/Lambda** dictionary key using this tag syntax.
 
@@ -161,11 +162,11 @@ Consequently, it is more difficult to automatically create alarms across differe
 
 The **disk_used_percent** metric for Linux has the additional dimensions:  **\'device', 'fstype', 'path'**.  For metrics with custom dimensions, you can include the dimension name and value in the tag key syntax:
 
-AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**DimensionName-DimensionValue...**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>
+AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**DimensionName-DimensionValue...**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>-\<**Description**>
 
 For example, the tag name used to create an alarm for the average **disk_used_percent** over a 5 minute period for the root partition on an Amazon Linux instance in the **CWAgent** namespace is:
 
-**AutoAlarm-CWAgent-disk_used_percent-device-xvda1-fstype-xfs-path-/-GreaterThanThreshold-5m-Average**
+**AutoAlarm-CWAgent-disk_used_percent-device-xvda1-fstype-xfs-path-/-GreaterThanThreshold-5m-Average-exampleDescription**
 
 Where the **device** dimension has a value of **xvda1**, the **fstype** dimension has a value of **xfs**, and the **path** dimension has a value of **/**.
 
@@ -180,11 +181,11 @@ You can create alarms that are specific to an individual EC2 instance by adding 
 
 For example, to add an alarm for the Amazon EC2 **StatusCheckFailed** CloudWatch metric for an existing EC2 instance:
 
-1. On the **Tags** tab, choose **Manage tags**, and then choose **Add tag**. For **Key**, enter **AutoAlarm-AWS/EC2-StatusCheckFailed-GreaterThanThreshold-5m-Average**. For Value, enter **1**. Choose **Save**.
+1. On the **Tags** tab, choose **Manage tags**, and then choose **Add tag**. For **Key**, enter **AutoAlarm-AWS/EC2-StatusCheckFailed-GreaterThanThreshold-5m-Average-exampleDescription**. For Value, enter **1**. Choose **Save**.
 
 2. Stop and start the Amazon EC2 instance.
 
-3. After the instance is stopped and restarted, go to the **Alarms** page in the CloudWatch console to confirm that the alarm was created.  You should find a new alarm named **AutoAlarm-<instance id omitted>-StatusCheckFailed-GreaterThanThreshold-1-5m**.
+3. After the instance is stopped and restarted, go to the **Alarms** page in the CloudWatch console to confirm that the alarm was created.  You should find a new alarm named **AutoAlarm-<instance id omitted>-StatusCheckFailed-GreaterThanThreshold-1-5m-exampleDescription**.
 
 ## Creating a specific alarm for a specific AWS Lambda function using tags
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The default configuration also creates alarms for the following [AWS Lambda metr
 
 You can change or add alarms by updating the **default_alarms** dictionary in [cw_auto_alarms.py](src/cw_auto_alarms.py).
 
-The created alarms can be configured to notify an Amazon SNS topic that you specify using the **DEFAULT_ALARM_SNS_TOPIC_ARN** environment variable.  See the **Setup** section for details.    
+The created alarms can be configured to notify an Amazon SNS topic that you specify using the **DEFAULT_ALARM_SNS_TOPIC_ARN** environment variable.  See the **Setup** section for details.
 
-The Amazon CloudWatch alarms are created when an EC2 instance with the tag key **Create_Auto_Alarms** enters the **running** state and they are deleted when the instance is **terminated**.  
+The Amazon CloudWatch alarms are created when an EC2 instance with the tag key **Create_Auto_Alarms** enters the **running** state and they are deleted when the instance is **terminated**.
 Alarms can be created when an instance is first launched or afterwards by stopping and starting the instance.
 
 The alarms are created and configured based on EC2 tags which include the metric name, comparison, period, statistic, and threshold.
@@ -30,26 +30,26 @@ AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**ComparisonOperator**>-\<**Perio
 
 Where:
 
-* **Namespace** is the CloudWatch Alarms namespace for the metric.  For AWS provided EC2 metrics, this is **AWS/EC2**.  For CloudWatch agent provided metrics, this is CWAgent by default.  
-You can also specify a different name as described in the **Configuration** section.   
+* **Namespace** is the CloudWatch Alarms namespace for the metric.  For AWS provided EC2 metrics, this is **AWS/EC2**.  For CloudWatch agent provided metrics, this is CWAgent by default.
+You can also specify a different name as described in the **Configuration** section.
 * **MetricName** is the name of the metric.  For example, CPUUtilization for EC2 total CPU utilization.
 * **ComparisonOperator** is the comparison that should be used aligning to the ComparisonOperator parameter in the [PutMetricData](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html) Amazon CloudWatch API action.
 * **Period** is the length of time used to evaluate the metric.  You can specify an integer value followed by s for seconds, m for minutes, h for hours, d for days, and w for weeks.  Your evaluation period should observe CloudWatch evaluation period limits.
-* **Statistic** is the statistic for the MetricName specified, other than percentile.  
+* **Statistic** is the statistic for the MetricName specified, other than percentile.
 
 The tag value is used to specify the threshold.  You can also [create alarms for custom Amazon CloudWatch metrics](#alarming-on-custom-amazon-ec2-metrics).
 
 For example, one of the preconfigured, default alarms that are included in the **default_alarms** dictionary is **AutoAlarm-AWS/EC2-CPUUtilization-GreaterThanThreshold-5m-Average**.
 When an instance with the tag key **Create_Auto_Alarms** enters the **running** state, an alarm for the AWS provided **CPUUtilization** CloudWatch EC2 metric will be created.
-Additional alarms will also be created for the EC2 instance based on the platform and alarms defined in the **default_alarms** python dictionary defined in [cw_auto_alarms.py](src/cw_auto_alarms.py).  
+Additional alarms will also be created for the EC2 instance based on the platform and alarms defined in the **default_alarms** python dictionary defined in [cw_auto_alarms.py](src/cw_auto_alarms.py).
 
 Alarms can be updated by changing the tag key or value and stopping and starting the instance.
 
 ## Requirements
 1.  The AWS CLI is required to deploy the Lambda function using the deployment instructions.
-2.  The AWS CLI should be configured with valid credentials to create the CloudFormation stack, lambda function, and related resources.  You must also have rights to upload new objects to the S3 bucket you specify in the deployment steps.  
+2.  The AWS CLI should be configured with valid credentials to create the CloudFormation stack, lambda function, and related resources.  You must also have rights to upload new objects to the S3 bucket you specify in the deployment steps.
 3.  EC2 instances must have the CloudWatch agent installed and configured with [the basic, standard, or advanced predefined metric sets](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html) in order for the default alarms for custom CloudWatch metrics to work.  Scripts named [userdata_linux_basic.sh](./userdata_linux_basic.sh), [userdata_linux_standard.sh](./userdata_linux_standard.sh), and [userdata_linux_advanced.sh](./userdata_linux_advanced.sh) are provided to install and configure the CloudWatch agent on Linux based EC2 instances with their respective predefined metric sets.
-   
+
 ## Setup
 There are a number of settings that can be customized by updating the CloudWatchAutoAlarms Lambda function environment variables defined in the [CloudWatchAutoAlarms.yaml](./CloudWatchAutoAlarms.yaml) CloudFormation template.
 The settings will only affect new alarms that you create so you should customize these values to meet your requirements before you deploy the Lambda function.
@@ -61,7 +61,7 @@ The following list provides a description of the setting along with the environm
     * When true, this will result in the default alarm set being created when the **Create_Auto_Alarms** tag is present.  If set to false, then alarms will be created only for the alarm tags  defined on the instance.
 * **CLOUDWATCH_NAMESPACE**: CWAgent
     * You can change the namespace where the Lambda function should look for your CloudWatch metrics. The default CloudWatch agent metrics namespace is CWAgent.  If your CloudWatch agent configuration is using a different namespace, then update the  CLOUDWATCH_NAMESPACE environment variable.
-* **CLOUDWATCH_APPEND_DIMENSIONS**: InstanceId, ImageId, InstanceType, AutoScalingGroupName 
+* **CLOUDWATCH_APPEND_DIMENSIONS**: InstanceId, ImageId, InstanceType, AutoScalingGroupName
     * You can add EC2 metric dimensions to all metrics collected by the CloudWatch agent.  This environment variable aligns to your CloudWatch configuration setting for [**append_dimensions**](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Metricssection).  The default setting includes all the supported dimensions:  InstanceId, ImageId, InstanceType, AutoScalingGroupName
 * **DEFAULT_ALARM_SNS_TOPIC_ARN**:  arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:CloudWatchAutoAlarmsSNSTopic
     * You can define an Amazon Simple Notification Service (Amazon SNS) topic that the Lambda function will specify as the notification target for created alarms. You provide the Amazon SNS Topic Amazon Resource Name (ARN) with the **AlarmNotificationARN** parameter when you deploy the CloudWatchAutoAlarms.yaml CloudFormation template.  If you leave the **AlarmNotificationARN** parameter value blank, then this environment variable is not set and created alarms won't use notifications.
@@ -73,11 +73,11 @@ The following list provides a description of the setting along with the environm
     * **ALARM_MEMORY_HIGH_THRESHOLD**: 75
     * **ALARM_DISK_PERCENT_LOW_THRESHOLD**: 20
 
-   **For AWS Lambda**: 
+   **For AWS Lambda**:
     * **ALARM_LAMBDA_ERROR_THRESHOLD**: 0
     * **ALARM_LAMBDA_THROTTLE_THRESHOLD**: 0
-    
-## Deploy 
+
+## Deploy
 
 1. Clone the amazon-cloudwatch-auto-alarms github repository to your computer using the following command:
 
@@ -85,9 +85,9 @@ The following list provides a description of the setting along with the environm
 2. Configure the AWS CLI with credentials for your AWS account.  This walkthrough uses temporary credentials provided by AWS Single Sign On using the **Command line or programmatic access** option.  This sets the **AWS_ACCESS_KEY_ID**, **AWS_SECRET_ACCESS_KEY**, and **AWS_SESSION_TOKEN** AWS environment variables with the appropriate credentials for use with the AWS CLI.
 3. Create an Amazon SNS topic that CloudWatchAutoAlarms will use for notifications. You can use this sample Amazon SNS CloudFormation template to create an SNS topic.  Leave the OrganizationID parameter blank, it is used for multi-account deployments.
 
-       aws cloudformation create-stack --stack-name amazon-cloudwatch-auto-alarms-sns-topic \ 
-       --template-body file://CloudWatchAutoAlarms-SNS.yaml \ 
-       --parameters ParameterKey=OrganizationID,ParameterValue="" \ 
+       aws cloudformation create-stack --stack-name amazon-cloudwatch-auto-alarms-sns-topic \
+       --template-body file://CloudWatchAutoAlarms-SNS.yaml \
+       --parameters ParameterKey=OrganizationID,ParameterValue="" \
        --region <enter your aws region id, e.g. "us-east-1">
 4. Create an S3 bucket that will be used to store and access the CloudWatchAutoAlarms lambda function deployment package if you don't have one.  You can use [this sample S3 CloudFormation template](./CloudWatchAutoAlarms-S3.yaml).  You can leave the AWS Organizations ID parameter blank if this lambda function will only be deployed in your current account:
 
@@ -99,7 +99,7 @@ The following list provides a description of the setting along with the environm
 6. Create a zip file containing the CloudWatchAutoAlarms AWS Lambda function code located in the [src](./src) directory.  This is the deployment package that you will use to deploy the AWS Lambda function.  On a Mac, you can use the zip command:
 
        zip -j amazon-cloudwatch-auto-alarms.zip src/*
-7. Copy the **amazon-cloudwatch-auto-alarms.zip** file to your S3 bucket. 
+7. Copy the **amazon-cloudwatch-auto-alarms.zip** file to your S3 bucket.
 
        aws s3 cp amazon-cloudwatch-auto-alarms.zip s3://<bucket name>
 
@@ -119,9 +119,9 @@ The following list provides a description of the setting along with the environm
        ParameterKey=S3DeploymentBucket,ParameterValue=<S3 bucket with your deployment package> \
        ParameterKey=AlarmNotificationARN,ParameterValue=<SNS Topic ARN for Alarm Notifications> \
        --region <enter your aws region id, e.g. "us-east-1">
- 
-   If you don't want to enable SNS notifications, you can set the **ParameterValue** to **""** for **AlarmNotificationARN**. 
-   
+
+   If you don't want to enable SNS notifications, you can set the **ParameterValue** to **""** for **AlarmNotificationARN**.
+
    You can retrieve the SNS Topic ARN from step #3 for the **AlarmNotificationARN** parameter value by running the following command:
 
        aws cloudformation describe-stacks --stack-name amazon-cloudwatch-auto-alarms-sns-topic \
@@ -138,7 +138,7 @@ For AWS Lambda, you can add this tag to an AWS Lambda function at any time in or
 
 
 ## Changing the default alarm set
-You can add, remove, and customize alarms in the default alarm set.  The default alarms are defined in the **default_alarms** python dictionary in [cw_auto_alarms.py](src/cw_auto_alarms.py).  
+You can add, remove, and customize alarms in the default alarm set.  The default alarms are defined in the **default_alarms** python dictionary in [cw_auto_alarms.py](src/cw_auto_alarms.py).
 
 In order to create an alarm, you must uniquely identify the metric that you want to alarm on.  Standard Amazon EC2 metrics include the **InstanceId** dimension to uniquely identify each standard metric associated with an EC2 instance.  If you want to add an alarm based upon a standard EC2 instance metric, then you can use the tag name syntax:
 
@@ -157,18 +157,18 @@ Metrics captured by the Amazon CloudWatch agent are considered custom metrics.  
 
 For example, the metric name used to measure the disk space utilization is named **disk_used_percent** in Linux and **LogicalDisk % Free Space** in Windows.  The dimensions are also different, in Linux you must also include the **device**, **fstype**, and **path** dimensions in order to uniquely identify a disk.  In Windows, you must include the **objectname** and **instance** dimensions.
 
-Consequently, it is more difficult to automatically create alarms across different platforms for custom CloudWatch EC2 instance metrics.  
+Consequently, it is more difficult to automatically create alarms across different platforms for custom CloudWatch EC2 instance metrics.
 
-The **disk_used_percent** metric for Linux has the additional dimensions:  **\'device', 'fstype', 'path'**.  For metrics with custom dimensions, you can include the dimension name and value in the tag key syntax:  
+The **disk_used_percent** metric for Linux has the additional dimensions:  **\'device', 'fstype', 'path'**.  For metrics with custom dimensions, you can include the dimension name and value in the tag key syntax:
 
-AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**DimensionName-DimensionValue...**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**> 
+AutoAlarm-\<**Namespace**>-\<**MetricName**>-\<**DimensionName-DimensionValue...**>-\<**ComparisonOperator**>-\<**Period**>-\<**Statistic**>
 
 For example, the tag name used to create an alarm for the average **disk_used_percent** over a 5 minute period for the root partition on an Amazon Linux instance in the **CWAgent** namespace is:
 
 **AutoAlarm-CWAgent-disk_used_percent-device-xvda1-fstype-xfs-path-/-GreaterThanThreshold-5m-Average**
 
 Where the **device** dimension has a value of **xvda1**, the **fstype** dimension has a value of **xfs**, and the **path** dimension has a value of **/**.
- 
+
 This syntax and approach allows you to collectively support metrics with different numbers of dimensions and names.  Using this syntax, you can add alarms for metrics with custom dimensions to the appropriate platform in the **default_alarms** dictionary in [cw_auto_alarms.py](src/cw_auto_alarms.py)
 
 You should also make sure that the **CLOUDWATCH_APPEND_DIMENSIONS** environment variable is set correctly in order to ensure that created alarms include these dimensions.  The lambda function will dynamically lookup the values for these dimensions at runtime.
@@ -192,11 +192,11 @@ You can create alarms that are specific to an individual AWS Lambda function by 
 
 ## Deploying in a multi-region, multi-account environment
 
-You can deploy the CloudWatchAutoAlarms lambda function into a multi-account, multi-region environment by using [CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).  
+You can deploy the CloudWatchAutoAlarms lambda function into a multi-account, multi-region environment by using [CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
 
-Follow [steps 1 through 6 in the normal deployment process](#deploy).   For step #3 and step #4, enter your AWS Organizations ID for the **OrganizationID** parameter in the [sample S3 CloudFormation template](./CloudWatchAutoAlarms-S3.yaml) and [sample SNS CloudFormation template](./CloudWatchAutoAlarms-SNS.yaml).  This will update the resource policy to allow access to all accounts in your AWS organization.  
+Follow [steps 1 through 6 in the normal deployment process](#deploy).   For step #3 and step #4, enter your AWS Organizations ID for the **OrganizationID** parameter in the [sample S3 CloudFormation template](./CloudWatchAutoAlarms-S3.yaml) and [sample SNS CloudFormation template](./CloudWatchAutoAlarms-SNS.yaml).  This will update the resource policy to allow access to all accounts in your AWS organization.
 
-Continue with the following steps to deploy a service managed AWS StackSet for the CloudWatchAutoAlarms lambda function.  This will deploy the CloudWatchAutoAlarms Lambda function into the organization units that you specify.  The lambda function will also be automatically deployed to new accounts in the AWS organization. 
+Continue with the following steps to deploy a service managed AWS StackSet for the CloudWatchAutoAlarms lambda function.  This will deploy the CloudWatchAutoAlarms Lambda function into the organization units that you specify.  The lambda function will also be automatically deployed to new accounts in the AWS organization.
 
 1. Use the [CloudWatchAutoAlarms CloudFormation template](./CloudWatchAutoAlarms.yaml) to deploy the Lambda function across multiple regions and accounts in your AWS Organization.  This walkthrough deploys a service managed CloudFormation StackSet in the AWS Organizations master account.  You must also specify the account ID where the S3 deployment bucket was created so the same S3 bucket is used across account deployments in your organization.  Use the following command to deploy the service managed CloudFormation StackSet:
 
@@ -217,7 +217,7 @@ Continue with the following steps to deploy a service managed AWS StackSet for t
        --regions <enter the target regions where the lambda function should be deployed e.g. "us-east-1"> \
        --region <enter your aws region id, e.g. "us-east-1">
 
-   You can monitor the progress and status of the StackSet operation in the AWS CloudFormation service console.  
+   You can monitor the progress and status of the StackSet operation in the AWS CloudFormation service console.
 
    Once the deployment is complete, the status will change from **RUNNING** to **SUCCEEDED**.
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -183,11 +183,11 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
 
     AlarmName += alarm_separator.join(['', ComparisonOperator, Period, Statistic])
 
-    # add the description to the alarm name. If none are specified, use a default description
+    # add the description to the alarm name. If none are specified, log a message
     try:
         AlarmName += '-' + alarm_properties[(properties_offset + 6)]
     except:
-        AlarmName += '-defaultdescription'
+        logger.info('Description not supplied')
 
     create_alarm(AlarmName, MetricName, ComparisonOperator, Period, alarm_tag['Value'], Statistic, namespace,
                  dimensions, sns_topic_arn)

--- a/src/actions.py
+++ b/src/actions.py
@@ -145,7 +145,8 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
 
     additional_dimensions = list()
 
-    for index, prop in enumerate(alarm_properties[3:], start=3):
+    # exclude last element which is the DESCRIPTION that differentiates alarms
+    for index, prop in enumerate(alarm_properties[3:-1], start=3):
         if prop in valid_comparators:
             prop_end_index = index
             break
@@ -181,6 +182,12 @@ def create_alarm_from_tag(id, alarm_tag, instance_info, metric_dimensions_map, s
     Statistic = alarm_properties[(properties_offset + 5)]
 
     AlarmName += alarm_separator.join(['', ComparisonOperator, Period, Statistic])
+
+    # add the description to the alarm name. If none are specified, use a default description
+    try:
+        AlarmName += '-' + alarm_properties[(properties_offset + 6)]
+    except:
+        AlarmName += '-defaultdescription'
 
     create_alarm(AlarmName, MetricName, ComparisonOperator, Period, alarm_tag['Value'], Statistic, namespace,
                  dimensions, sns_topic_arn)

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -31,27 +31,29 @@ alarm_identifier = 'AutoAlarm'
 # For Redhat, the default device is xvda2, xfs, for Ubuntu, the default fstype is ext4,
 # for Amazon Linux, the default device is xvda1, xfs
 default_alarms = {
+    # default<number> added to the end of the key to  make the key unique
+    # this differentiate alarms with similar settings but different thresholds
     'AWS/EC2': [
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/EC2', 'CPUUtilization', 'GreaterThanThreshold', '5m', 'Average']),
+                [alarm_identifier, 'AWS/EC2', 'CPUUtilization', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
             'Value': alarm_cpu_high_default_threshold
         },
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/EC2', 'CPUCreditBalance', 'LessThanThreshold', '5m', 'Average']),
+                [alarm_identifier, 'AWS/EC2', 'CPUCreditBalance', 'LessThanThreshold', '5m', 'Average', 'default1']),
             'Value': alarm_credit_balance_low_default_threshold
         }
     ],
     'AWS/Lambda': [
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/Lambda', 'Errors', 'GreaterThanThreshold', '5m', 'Average']),
+                [alarm_identifier, 'AWS/Lambda', 'Errors', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
             'Value': alarm_lambda_error_threshold
         },
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/Lambda', 'Throttles', 'GreaterThanThreshold', '5m', 'Average']),
+                [alarm_identifier, 'AWS/Lambda', 'Throttles', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
             'Value': alarm_lambda_throttles_threshold
         }
     ],
@@ -61,13 +63,13 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'LogicalDisk % Free Space', 'objectname', 'LogicalDisk',
-                     'instance', 'C:', 'LessThanThreshold', '5m', 'Average']),
+                     'instance', 'C:', 'LessThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_disk_space_percent_free_threshold
             },
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'Memory % Committed Bytes In Use', 'objectname', 'Memory',
-                     'GreaterThanThreshold', '5m', 'Average']),
+                     'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_memory_high_default_threshold
             }
         ],
@@ -75,12 +77,12 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'disk_used_percent', 'device', 'xvda1', 'fstype', 'xfs', 'path',
-                     '/', 'GreaterThanThreshold', '5m', 'Average']),
+                     '/', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_disk_used_percent_threshold
             },
             {
                 'Key': alarm_separator.join(
-                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average']),
+                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_memory_high_default_threshold
             }
         ],
@@ -88,12 +90,12 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'disk_used_percent', 'device', 'xvda2', 'fstype', 'xfs', 'path',
-                     '/', 'GreaterThanThreshold', '5m', 'Average']),
+                     '/', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_disk_used_percent_threshold
             },
             {
                 'Key': alarm_separator.join(
-                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average']),
+                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_memory_high_default_threshold
             }
         ],
@@ -101,12 +103,12 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'disk_used_percent', 'device', 'xvda1', 'fstype', 'ext4', 'path',
-                     '/', 'GreaterThanThreshold', '5m', 'Average']),
+                     '/', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_disk_used_percent_threshold
             },
             {
                 'Key': alarm_separator.join(
-                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average']),
+                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_memory_high_default_threshold
             }
         ],
@@ -114,12 +116,12 @@ default_alarms = {
             {
                 'Key': alarm_separator.join(
                     [alarm_identifier, cw_namespace, 'disk_used_percent', 'device', 'xvda1', 'fstype', 'xfs', 'path',
-                     '/', 'GreaterThanThreshold', '5m', 'Average']),
+                     '/', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_disk_used_percent_threshold
             },
             {
                 'Key': alarm_separator.join(
-                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average']),
+                    [alarm_identifier, cw_namespace, 'mem_used_percent', 'GreaterThanThreshold', '5m', 'Average', 'default1']),
                 'Value': alarm_memory_high_default_threshold
             }
         ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently alarms created cannot have similar settings and different thresholds because the `put_metric_alarm` replaces alarms with the same name (the `key` that goes into the alarm name is the same). This means we cannot have alarms that have similar settings but different thresholds. Adding a description to the end of the alarm name differentiates alarms. This description is added to the Tag Key and the Default map of keys and is appended to the end of the alarm name. Hence, we can now have alarms with similar settings but different thresholds.

To ensure backward compatibility, we check if the last element exists by using `properties_offset + 6`. If there is an error, that means users have not entered a description. In this situation, we just log that the user did not specify a description. The behaviour of their alarms would remain the same.

However, if users have old alarms without a description and suddenly add the description in, the old alarms will not be deleted. Instead, only the new alarms with the description will be created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
