### PR TITLE
Fix error on describe-instance call tag filter

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -45,7 +45,7 @@ def check_alarm_tag(instance_id, tag_key):
         instance = ec2_client.describe_instances(
             Filters=[
                 {
-                    'Name': 'tag-key',
+                    'Name': 'tag:tag-key',
                     'Values': [
                         tag_key
                     ]


### PR DESCRIPTION
Fix for: https://github.com/aws-samples/amazon-cloudwatch-auto-alarms/issues/35

'Name': 'tag:tag-key',

Not:
'Name': 'tag-key',

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
