### PR TITLE
flushed out userdata script adn added env vars

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -45,7 +45,7 @@ def check_alarm_tag(instance_id, tag_key):
         instance = ec2_client.describe_instances(
             Filters=[
                 {
-                    'Name': 'tag:tag-key',
+                    'Name': 'tag-key',
                     'Values': [
                         tag_key
                     ]

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -21,22 +21,27 @@ alarm_cpu_high_default_threshold = getenv("ALARM_CPU_HIGH_THRESHOLD", "75")
 alarm_memory_high_default_threshold = getenv("ALARM_MEMORY_HIGH_THRESHOLD", "75")
 alarm_disk_space_percent_free_threshold = getenv("ALARM_DISK_PERCENT_LOW_THRESHOLD", "20")
 alarm_disk_used_percent_threshold = 100 - int(alarm_disk_space_percent_free_threshold)
+default_period = getenv("ALARM_DEFAULT_PERIOD", "5m")
+default_evaluation_periods = getenv("ALARM_DEFAULT_EVALUATION_PERIOD", "1")
+default_statistic = getenv("ALARM_DEFAULT_STATISTIC", "Average")
 
 alarm_rds_cpu_high_default_threshold = getenv("ALARM_RDS_CPU_HIGH_THRESHOLD", "75")
+default_rds_period = getenv("ALARM_DEFAULT_RDS_PERIOD", "5m")
+default_rds_evaluation_periods = getenv("ALARM_DEFAULT_RDS_EVALUATION_PERIOD", "1")
+default_rds_statistic = getenv("ALARM_DEFAULT_RDS_STATISTIC", "Average")
 
 alarm_lambda_error_threshold = getenv("ALARM_LAMBDA_ERROR_THRESHOLD", "1")
 alarm_lambda_throttles_threshold = getenv("ALARM_LAMBDA_THROTTLE_THRESHOLD", "1")
 alarm_lambda_dead_letter_error_threshold = getenv("ALARM_LAMBDA_DEAD_LETTER_ERROR_THRESHOLD", "1")
 alarm_lambda_destination_delivery_failure_threshold = getenv("ALARM_LAMBDA_DESTINATION_DELIVERY_FAILURE_THRESHOLD", "1")
+default_lambda_period = getenv("ALARM_DEFAULT_LAMBDA_PERIOD", "5m")
+default_lambda_evaluation_periods = getenv("ALARM_DEFAULT_LAMBDA_EVALUATION_PERIOD", "1")
+default_lambda_statistic = getenv("ALARM_DEFAULT_LAMBDA_STATISTIC", "Average")
 
 sns_topic_arn = getenv("DEFAULT_ALARM_SNS_TOPIC_ARN", None)
 
 alarm_separator = '-'
 alarm_identifier = getenv("ALARM_IDENTIFIER_PREFIX", 'AutoAlarm')
-
-default_period = '5m'
-default_evaluation_periods = '1'
-default_statistic = 'Average'
 
 # For Redhat, the default device is xvda2, xfs, for Ubuntu, the default fstype is ext4,
 # for Amazon Linux, the default device is xvda1, xfs
@@ -46,8 +51,8 @@ default_alarms = {
     'AWS/RDS': [
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/RDS', 'CPUUtilization', 'GreaterThanThreshold', default_period,
-                 default_evaluation_periods, default_statistic, 'Created_by_CloudWatchAutoAlarms']),
+                [alarm_identifier, 'AWS/RDS', 'CPUUtilization', 'GreaterThanThreshold', default_rds_period,
+                 default_rds_evaluation_periods, default_rds_statistic, 'Created_by_CloudWatchAutoAlarms']),
             'Value': alarm_rds_cpu_high_default_threshold
         }
     ],
@@ -62,14 +67,14 @@ default_alarms = {
     'AWS/Lambda': [
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/Lambda', 'Errors', 'GreaterThanThreshold', default_period,
-                 default_evaluation_periods, default_statistic, 'Created_by_CloudWatchAutoAlarms']),
+                [alarm_identifier, 'AWS/Lambda', 'Errors', 'GreaterThanThreshold', default_lambda_period,
+                 default_lambda_evaluation_periods, default_lambda_statistic, 'Created_by_CloudWatchAutoAlarms']),
             'Value': alarm_lambda_error_threshold
         },
         {
             'Key': alarm_separator.join(
-                [alarm_identifier, 'AWS/Lambda', 'Throttles', 'GreaterThanThreshold', default_period,
-                 default_evaluation_periods, default_statistic, 'Created_by_CloudWatchAutoAlarms']),
+                [alarm_identifier, 'AWS/Lambda', 'Throttles', 'GreaterThanThreshold', default_lambda_period,
+                 default_lambda_evaluation_periods, default_lambda_statistic, 'Created_by_CloudWatchAutoAlarms']),
             'Value': alarm_lambda_throttles_threshold
         }
     ],

--- a/userdata_linux_basic.sh
+++ b/userdata_linux_basic.sh
@@ -1,23 +1,52 @@
 #!/usr/bin/env bash
 # comment out the appropriate linux version for install
+source /etc/os-release
+if [[ $ID == 'amzn' ]] ; then
+  # Amazon Linux
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
+  yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
 
-# Amazon Linux
-wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
-# Redhat
-# curl -o /tmp/cwagent.rpm https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
-# SUSE
-# wget https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
-# Debian
-# wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/cwagent.deb
-# Ubuntu
-# curl -o /tmp/cwagent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+elif [[ $ID == 'rhel' ]]; then
+  # Redhat
+  curl -o /tmp/cwagent.rpm https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
+  yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
+elif [[ $ID == 'sles' ]]; then
+  # SUSE
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
+  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  rpm --install amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
 
-# For RPM install, uncoment next line
-rpm -U /tmp/cwagent.rpm
+elif [[ $ID == 'debian' ]]; then
+  # Debian
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/cwagent.deb
+  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+  dpkg -i amazon-ssm-agent.deb
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
+elif [[ $ID == 'ubuntu' ]] ; then
+  # Ubuntu
+   curl -o /tmp/cwagent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+   snap switch --channel=candidate amazon-ssm-agent
+   sudo snap install amazon-ssm-agent --classic
+  systemctl enable amazon-ssm-agent
+  systemctl enable  snap.amazon-ssm-agent.amazon-ssm-agent.service
+  systemctl restart  snap.amazon-ssm-agent.amazon-ssm-agent.service
 
-# For Debian package install, uncoment next line
-# dpkg -i -E ./cwagent.deb
+fi
 
+if [[ $ID_LIKE == 'fedora' ]] || [[ $ID_LIKE == 'suse'  ]]; then
+  # For RPM install, uncoment next line
+  rpm -U /tmp/cwagent.rpm
+elif [[ $ID_LIKE == 'debian' ]] || [[ $ID == 'debian'  ]]; then
+  # For Debian package install, uncoment next line
+  dpkg -i -E ./cwagent.deb
+fi
 
 cat > /tmp/cwconfig.json <<"EOL"
 {

--- a/userdata_linux_standard.sh
+++ b/userdata_linux_standard.sh
@@ -1,23 +1,52 @@
 #!/usr/bin/env bash
 # comment out the appropriate linux version for install
+source /etc/os-release
+if [[ $ID == 'amzn' ]] ; then
+  # Amazon Linux
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
+  yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
 
-# Amazon Linux
-wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
-# Redhat
-# curl -o /tmp/cwagent.rpm https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
-# SUSE
-# wget https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
-# Debian
-# wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/cwagent.deb
-# Ubuntu
-# curl -o /tmp/cwagent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+elif [[ $ID == 'rhel' ]]; then
+  # Redhat
+  curl -o /tmp/cwagent.rpm https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
+  yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
+elif [[ $ID == 'sles' ]]; then
+  # SUSE
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/cwagent.rpm
+  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  rpm --install amazon-ssm-agent.rpm
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
 
-# For RPM install, uncoment next line
-rpm -U /tmp/cwagent.rpm
+elif [[ $ID == 'debian' ]]; then
+  # Debian
+  wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/cwagent.deb
+  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+  dpkg -i amazon-ssm-agent.deb
+  systemctl enable amazon-ssm-agent
+  systemctl restart amazon-ssm-agent
+elif [[ $ID == 'ubuntu' ]] ; then
+  # Ubuntu
+   curl -o /tmp/cwagent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+   snap switch --channel=candidate amazon-ssm-agent
+   sudo snap install amazon-ssm-agent --classic
+  systemctl enable amazon-ssm-agent
+  systemctl enable  snap.amazon-ssm-agent.amazon-ssm-agent.service
+  systemctl restart  snap.amazon-ssm-agent.amazon-ssm-agent.service
 
-# For Debian package install, uncoment next line
-# dpkg -i -E ./cwagent.deb
+fi
 
+if [[ $ID_LIKE == 'fedora' ]] || [[ $ID_LIKE == 'suse'  ]]; then
+  # For RPM install, uncoment next line
+  rpm -U /tmp/cwagent.rpm
+elif [[ $ID_LIKE == 'debian' ]] || [[ $ID == 'debian'  ]]; then
+  # For Debian package install, uncoment next line
+  dpkg -i -E ./cwagent.deb
+fi
 
 cat > /tmp/cwconfig.json <<"EOL"
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
src/cw_auto_alarms.py
Took the following constants:
	default_period = '5m'
	default_evaluation_periods = '1'
	default_statistic = 'Average'
Added unique env vars for each: ec2, lambda and rds
For instance in my shop,  unless RDS CPU is 100% for over 90 minutes, do not care.

Flushed out and used /etc/os-release to make calls OS dependent instead of having to comment or not comment.
even if this is meant as an example to put in your own userdata, makes life easier when checking out this tool.
userdata_linux_advanced.sh
userdata_linux_basic.sh
userdata_linux_standard.sh

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
