### PR TITLE
Fix/check sns topic arn empty str

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -483,7 +483,7 @@ def create_alarm(AlarmName, AlarmDescription, MetricName, ComparisonOperator, Pe
         else:
             alarm['Threshold'] = Threshold
 
-        if sns_topic_arn is not None:
+        if sns_topic_arn and sns_topic_arn != '':
             alarm['AlarmActions'] = [sns_topic_arn]
 
         cw_client.put_metric_alarm(**alarm)


### PR DESCRIPTION
check sns topic arn empty str before setting AlarmActions Param validation failed:
Invalid length for parameter AlarmActions[0], value: 0, valid min length: 1

*Issue #, if available:*

*Description of changes:*

In the CloudFormation stack, `AlarmNotificationARN` defaults to empty string. When passed to AlarmActions for CloudWatch Alarms, this results in the error `Parameter validation failed:
Invalid length for parameter AlarmActions[0], value: 0, valid min length: 1`.

Fix: Check for empty string before setting AlarmActions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
