### PR TITLE
Fix CloudWatchAutoAlarms-SNS.yaml to allow CloudWatch Alarms to Publish to SNS Topic from Any Account in a Organization

### DIFF
--- a/CloudWatchAutoAlarms-SNS.yaml
+++ b/CloudWatchAutoAlarms-SNS.yaml
@@ -56,8 +56,8 @@ Resources:
                 - !Ref CloudWatchAutoAlarmsSNSTopic
               Condition:
                 StringLike:
-                  aws:PrincipalOrgPaths:
-                    - !Sub "${TargetOrganizationId}/*"
+                  aws:SourceOrgID:
+                    - !Sub "${TargetOrganizationId}"
             - !Ref "AWS::NoValue"
 
 Outputs:


### PR DESCRIPTION
*Description of changes:*
Since the policy Principal is an AWS service principal, the aws:PrincipalOrgPaths property key will not work.
Use, instead, SourceOrgID key to compare the organization ID of the resource making a service-to-service request with the organization ID that you specify in the policy when the request is made by an AWS service principal. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
