### PR TITLE
Allow skipping the creation of default CloudWatch alarms for specific EC2 instances by using a new tag Skip_Default_Alarms

### DIFF
--- a/CloudWatchAutoAlarms.yaml
+++ b/CloudWatchAutoAlarms.yaml
@@ -146,6 +146,7 @@ Resources:
         Variables:
           ALARM_TAG: Create_Auto_Alarms
           CREATE_DEFAULT_ALARMS: true
+          SKIP_DEFAULT_ALARMS_TAG: Skip_Default_Alarms
           LOCAL_ACCOUNT_ID: !Ref AWS::AccountId
           CLOUDWATCH_NAMESPACE: CWAgent
           ALARM_CPU_HIGH_THRESHOLD: 75

--- a/src/cw_auto_alarms.py
+++ b/src/cw_auto_alarms.py
@@ -25,6 +25,7 @@ def lambda_handler(event, context):
     cw_namespace = getenv("CLOUDWATCH_NAMESPACE", "CWAgent")
 
     create_default_alarms_flag = getenv("CREATE_DEFAULT_ALARMS", "true").lower()
+    skip_default_alarms_tag = getenv("SKIP_DEFAULT_ALARMS_TAG", "Skip_Default_Alarms").lower()
 
     append_dimensions = getenv("CLOUDWATCH_APPEND_DIMENSIONS", 'InstanceId, ImageId, InstanceType')
     append_dimensions = [dimension.strip() for dimension in append_dimensions.split(',')]
@@ -294,14 +295,14 @@ def lambda_handler(event, context):
                             logger.info(f"Processing region {region}")
                             # Call scan_and_process_alarm_tags for the account and region
                             scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensions_map, sns_topic_arn,
-                                                        cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier, region, account_id)
+                                                        cw_namespace, create_default_alarms_flag, skip_default_alarms_tag, alarm_separator, alarm_identifier, region, account_id)
             else:
                 # Call scan_and_process_alarm_tags for single account
                 for region in target_regions:
                     logger.info(f"Processing region {region}")
                     # Call scan_and_process_alarm_tags for the account and region
                     scan_and_process_alarm_tags(create_alarm_tag, default_alarms, metric_dimensions_map, sns_topic_arn,
-                                                cw_namespace, create_default_alarms_flag, alarm_separator, alarm_identifier, region)
+                                                cw_namespace, create_default_alarms_flag, skip_default_alarms_tag, alarm_separator, alarm_identifier, region)
 
     except Exception as e:
         # If any other exceptions which we didn't expect are raised


### PR DESCRIPTION
This pull request introduces a new feature to allow skipping the creation of default CloudWatch alarms for specific EC2 instances by using a new tag, `Skip_Default_Alarms`. The changes involve adding support for this tag across the CloudFormation template, environment variables, and the alarm processing logic. Below are the key updates:

### Feature Addition: Support for Skipping Default Alarms

* **CloudFormation Template Update**:
  - Added a new variable `SKIP_DEFAULT_ALARMS_TAG` in `CloudWatchAutoAlarms.yaml` to define the tag used to skip default alarms.

* **Environment Variable Support**:
  - Introduced `SKIP_DEFAULT_ALARMS_TAG` as an environment variable in `src/cw_auto_alarms.py` to make the tag configurable.

* **Function Signature Updates**:
  - Updated the `scan_and_process_alarm_tags` function in `src/actions.py` to accept the new `skip_default_alarms_tag` parameter.

* **Alarm Processing Logic**:
  - Enhanced the logic in `scan_and_process_alarm_tags` to check for the `Skip_Default_Alarms` tag on EC2 instances. If the tag is present, default alarms are not created for that instance.

* **Lambda Handler Integration**:
  - Modified calls to `scan_and_process_alarm_tags` in `src/cw_auto_alarms.py` to pass the `skip_default_alarms_tag` parameter.

* **Note for the Reviewers**:
In my Company/Org, we wanted to have the Default Alarms enabled globally - and created for **_almost all_** instances. However, there are instances where the default alarms are not suitable. For these instances, we are adding customized AutoAlarm tags instead e.g. alarming for 90% CPU rather than the default of 80%.